### PR TITLE
Apparently safari does not like vh / vw

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -11,7 +11,7 @@ body {
   /* Shift up a lil to fix the rendering bug seen on phone with 1px thick line */
   background-position: center calc(100% - 4px);
   background-repeat: repeat-y;
-  min-height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
Use % instead to be safer, since vw/vh can be wrong on safari