### PR TITLE
Fine tune Cowpoke + fix subtle bugs with data stores

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,6 +66,18 @@ Since this site is static, make sure to add "if (typeof window === \\"undefined\
 check before 'window' usage to prevent SSR errors. Add eslint-disable comment 
 if already protected, upstream or if dispositioned.`,
   },
+  {
+    selector:
+      "ExpressionStatement > CallExpression[callee.type='MemberExpression'][callee.object.name=/Store$/][callee.property.name=/^set[A-Z]/]",
+    message: `[Custom eslint.config.mjs rule] Store setter methods must be assigned to update local variables. 
+Example: 
+❌ gameDataStore.setPlayerHealth(newHealth);
+✅ this.health = gameDataStore.setPlayerHealth(newHealth);
+This enforces the pattern of keeping local properties in sync with store updates.
+This is a common source of bugs if not followed, since there is often a delay
+between store updates and local property updates. Add eslint-disable comment if 
+dispositioned.`,
+  },
 ];
 
 // TS-specific rule for all .ts files

--- a/src/games/better-boids/settings-store.ts
+++ b/src/games/better-boids/settings-store.ts
@@ -33,34 +33,46 @@ class SettingsStore extends SyncedStore<Settings> {
     return { ...this.data };
   }
 
-  public setAlignmentFactor(value: number) {
+  public setAlignmentFactor(value: number): number {
     this.data.alignmentFactor = value;
     this.notify();
+
+    return value;
   }
 
-  public setCohesionFactor(value: number) {
+  public setCohesionFactor(value: number): number {
     this.data.cohesionFactor = value;
     this.notify();
+
+    return value;
   }
 
-  public setSeparationFactor(value: number) {
+  public setSeparationFactor(value: number): number {
     this.data.separationFactor = value;
     this.notify();
+
+    return value;
   }
 
-  public setSpeed(value: number) {
+  public setSpeed(value: number): number {
     this.data.speed = value;
     this.notify();
+
+    return value;
   }
 
-  public setFlockSearchRadius(value: number) {
+  public setFlockSearchRadius(value: number): number {
     this.data.flockSearchRadius = value;
     this.notify();
+
+    return value;
   }
 
-  public setLeaderBoidEnabled(value: boolean) {
+  public setLeaderBoidEnabled(value: boolean): boolean {
     this.data.leaderBoidEnabled = value;
     this.notify();
+
+    return value;
   }
 
   public resetData() {

--- a/src/games/cowpoke/character.ts
+++ b/src/games/cowpoke/character.ts
@@ -621,23 +621,23 @@ export class Character extends GameObject {
 
   getCombatIncrease() {
     // +10% win chance per addCombat bonus from gun and hat
-    // +1% per permanentCombatBonus
+    // +0.5% per permanentCombatBonus
     return (
       0.1 *
         (GUN_LOOT_MAP[this.equippedGunId].addCombat +
           HAT_LOOT_MAP[this.equippedHatId].addCombat) +
-      0.01 * this.permanentCombatBonus
+      0.005 * this.permanentCombatBonus
     );
   }
 
   getElementIncrease() {
     // +10% win chance per addElement bonus from gun and hat
-    // +1% per permanentElementBonus
+    // +0.5% per permanentElementBonus
     return (
       0.1 *
         (GUN_LOOT_MAP[this.equippedGunId].addElement +
           HAT_LOOT_MAP[this.equippedHatId].addElement) +
-      0.01 * this.permanentElementBonus
+      0.005 * this.permanentElementBonus
     );
   }
 
@@ -645,7 +645,7 @@ export class Character extends GameObject {
     // Calculate base dmg + gun and hat bonuses.
     // Enemies have reduced base dmg.
     let baseDmg =
-      (5 + this.level * 0.2) * (this.type === CHARACTER_TYPES.ENEMY ? 0.8 : 1);
+      (5 + this.level * 0.2) * (this.type === CHARACTER_TYPES.ENEMY ? 0.55 : 1);
 
     // If in GOD_MODE, set base dmg to 999,999
     if (this.name === "GOD_MODE") {
@@ -825,9 +825,8 @@ export class Character extends GameObject {
     // Calculate new max health based on level, bonuses, and equipped items.
     // Enemies have reduced max health.
     let newMaxHealth =
-      10 +
-      (this.level * 1.2 + this.permanentHealthBonus) *
-        (this.type === CHARACTER_TYPES.ENEMY ? 0.75 : 1);
+      (10 + this.level * 1.2 + this.permanentHealthBonus) *
+      (this.type === CHARACTER_TYPES.ENEMY ? 0.55 : 1);
 
     newMaxHealth +=
       HAT_LOOT_MAP[this.equippedHatId].addHealth +

--- a/src/games/cowpoke/character.ts
+++ b/src/games/cowpoke/character.ts
@@ -225,17 +225,27 @@ export class Character extends GameObject {
       const { type } = customEvent.detail;
 
       if (type === "health") {
-        gameDataStore.setPermaHealthLevel(this.permanentHealthBonus + 1);
+        this.permanentHealthBonus = gameDataStore.setPermaHealthLevel(
+          this.permanentHealthBonus + 1
+        );
       } else if (type === "damage") {
-        gameDataStore.setPermaDamageLevel(this.permanentDamageBonus + 1);
+        this.permanentDamageBonus = gameDataStore.setPermaDamageLevel(
+          this.permanentDamageBonus + 1
+        );
       } else if (type === "combat") {
-        gameDataStore.setPermaCombatLevel(this.permanentCombatBonus + 1);
+        this.permanentCombatBonus = gameDataStore.setPermaCombatLevel(
+          this.permanentCombatBonus + 1
+        );
       } else if (type === "element") {
-        gameDataStore.setPermaElementLevel(this.permanentElementBonus + 1);
+        this.permanentElementBonus = gameDataStore.setPermaElementLevel(
+          this.permanentElementBonus + 1
+        );
       }
 
       // Update upgrade points
-      gameDataStore.setPlayerUpgradePoints(this.upgradePoints - 1);
+      this.upgradePoints = gameDataStore.setPlayerUpgradePoints(
+        this.upgradePoints - 1
+      );
     }
   };
 
@@ -328,7 +338,7 @@ export class Character extends GameObject {
 
     // Set level, this will set max health, xp, etc.
     this.updateLevel(5, true);
-    gameDataStore.setPlayerUpgradePoints(0); // player should start with 0 upgrade points
+    this.upgradePoints = gameDataStore.setPlayerUpgradePoints(0); // player should start with 0 upgrade points
 
     // Setup the character
     this.spawnCharacterSetup();
@@ -395,7 +405,7 @@ export class Character extends GameObject {
     );
 
     // Update name
-    gameDataStore.setEnemyName(
+    this.name = gameDataStore.setEnemyName(
       `${randomTitleOptions[randomTitleIndex]} ${randomNameOptions[randomNameIndex]}`
     );
 
@@ -462,9 +472,9 @@ export class Character extends GameObject {
     this.hatStarSprite!.setScale(0.7, 0.7);
 
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerEquippedHatId(id);
+      this.equippedHatId = gameDataStore.setPlayerEquippedHatId(id);
     } else if (this.type === CHARACTER_TYPES.ENEMY) {
-      gameDataStore.setEnemyEquippedHatId(id);
+      this.equippedHatId = gameDataStore.setEnemyEquippedHatId(id);
     }
     this.addNewOwnedHat(id);
 
@@ -509,9 +519,9 @@ export class Character extends GameObject {
     this.gunStarSprite!.setScale(0.6, 0.6);
 
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerEquippedGunId(id);
+      this.equippedGunId = gameDataStore.setPlayerEquippedGunId(id);
     } else if (this.type === CHARACTER_TYPES.ENEMY) {
-      gameDataStore.setEnemyEquippedGunId(id);
+      this.equippedGunId = gameDataStore.setEnemyEquippedGunId(id);
     }
 
     this.addNewOwnedGun(id);
@@ -593,7 +603,7 @@ export class Character extends GameObject {
       newOwnedHatIds.push(id);
 
       if (this.type === CHARACTER_TYPES.PLAYER) {
-        gameDataStore.setPlayerOwnedHatIds(newOwnedHatIds);
+        this.ownedHatIds = gameDataStore.setPlayerOwnedHatIds(newOwnedHatIds);
       }
     }
   }
@@ -604,7 +614,7 @@ export class Character extends GameObject {
       newOwnedGunIds.push(id);
 
       if (this.type === CHARACTER_TYPES.PLAYER) {
-        gameDataStore.setPlayerOwnedGunIds(newOwnedGunIds);
+        this.ownedGunIds = gameDataStore.setPlayerOwnedGunIds(newOwnedGunIds);
       }
     }
   }
@@ -635,7 +645,7 @@ export class Character extends GameObject {
     // Calculate base dmg + gun and hat bonuses.
     // Enemies have reduced base dmg.
     let baseDmg =
-      (5 + this.level * 0.2) * (this.type === CHARACTER_TYPES.ENEMY ? 0.25 : 1);
+      (5 + this.level * 0.2) * (this.type === CHARACTER_TYPES.ENEMY ? 0.8 : 1);
 
     // If in GOD_MODE, set base dmg to 999,999
     if (this.name === "GOD_MODE") {
@@ -805,9 +815,9 @@ export class Character extends GameObject {
     newHealth = Math.round(newHealth);
 
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerHealth(newHealth);
+      this.health = gameDataStore.setPlayerHealth(newHealth);
     } else if (this.type === CHARACTER_TYPES.ENEMY) {
-      gameDataStore.setEnemyHealth(newHealth);
+      this.health = gameDataStore.setEnemyHealth(newHealth);
     }
   }
 
@@ -815,8 +825,9 @@ export class Character extends GameObject {
     // Calculate new max health based on level, bonuses, and equipped items.
     // Enemies have reduced max health.
     let newMaxHealth =
-      (10 + this.level * 1.2 + this.permanentHealthBonus) *
-      (this.type === CHARACTER_TYPES.ENEMY ? 0.25 : 1);
+      10 +
+      (this.level * 1.2 + this.permanentHealthBonus) *
+        (this.type === CHARACTER_TYPES.ENEMY ? 0.75 : 1);
 
     newMaxHealth +=
       HAT_LOOT_MAP[this.equippedHatId].addHealth +
@@ -831,9 +842,9 @@ export class Character extends GameObject {
     newMaxHealth = Math.round(newMaxHealth);
 
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerMaxHealth(newMaxHealth);
+      this.maxHealth = gameDataStore.setPlayerMaxHealth(newMaxHealth);
     } else if (this.type === CHARACTER_TYPES.ENEMY) {
-      gameDataStore.setEnemyMaxHealth(newMaxHealth);
+      this.maxHealth = gameDataStore.setEnemyMaxHealth(newMaxHealth);
     }
   }
 
@@ -848,15 +859,19 @@ export class Character extends GameObject {
     }
 
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerLevel(newLevel);
+      this.level = gameDataStore.setPlayerLevel(newLevel);
     } else if (this.type === CHARACTER_TYPES.ENEMY) {
-      gameDataStore.setEnemyLevel(newLevel);
+      this.level = gameDataStore.setEnemyLevel(newLevel);
     }
 
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerUpgradePoints(this.upgradePoints + 1);
+      this.upgradePoints = gameDataStore.setPlayerUpgradePoints(
+        this.upgradePoints + 1
+      );
     } else if (this.type === CHARACTER_TYPES.ENEMY) {
-      gameDataStore.setEnemyUpgradePoints(this.upgradePoints + 1);
+      this.upgradePoints = gameDataStore.setEnemyUpgradePoints(
+        this.upgradePoints + 1
+      );
     }
 
     // Update max health on level up, then restore health
@@ -883,9 +898,9 @@ export class Character extends GameObject {
     }
 
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerXp(newXp);
+      this.xp = gameDataStore.setPlayerXp(newXp);
     } else if (this.type === CHARACTER_TYPES.ENEMY) {
-      gameDataStore.setEnemyXp(newXp);
+      this.xp = gameDataStore.setEnemyXp(newXp);
     }
 
     // Level up!
@@ -898,15 +913,15 @@ export class Character extends GameObject {
     const newMaxXp = 1 + this.level * 2;
 
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerMaxXp(newMaxXp);
+      this.maxXp = gameDataStore.setPlayerMaxXp(newMaxXp);
     } else if (this.type === CHARACTER_TYPES.ENEMY) {
-      gameDataStore.setEnemyMaxXp(newMaxXp);
+      this.maxXp = gameDataStore.setEnemyMaxXp(newMaxXp);
     }
   }
 
   handleKill(otherCharacter: Character) {
     if (this.type === CHARACTER_TYPES.PLAYER) {
-      gameDataStore.setPlayerKills(this.kills + 1);
+      this.kills = gameDataStore.setPlayerKills(this.kills + 1);
 
       const addXp = Math.floor(otherCharacter.level * 1.5);
 
@@ -974,7 +989,7 @@ export class Character extends GameObject {
         }
       }
     } else {
-      gameDataStore.setEnemyKills(this.kills + 1);
+      this.kills = gameDataStore.setEnemyKills(this.kills + 1);
 
       // Enemy says a quip when killing player
       sendFeedMessage(

--- a/src/games/cowpoke/game-data-store.ts
+++ b/src/games/cowpoke/game-data-store.ts
@@ -216,207 +216,283 @@ class GameDataStore extends SyncedStore<GameData> {
   }
 
   // Player methods
-  public setPlayerName(value: string) {
+  public setPlayerName(value: string): string {
     this.data.playerName = value;
     this.setLocalStorage("cowpokePlayerName", value);
     this.notify();
+
+    return value;
   }
 
-  public setPlayerLevel(value: number) {
+  public setPlayerLevel(value: number): number {
     this.data.playerLevel = value;
     this.notify();
+
+    return value;
   }
 
-  public setPlayerHealth(value: number) {
+  public setPlayerHealth(value: number): number {
     this.data.playerHealth = value;
     this.notify();
+
+    return value;
   }
 
-  public setPlayerMaxHealth(value: number) {
+  public setPlayerMaxHealth(value: number): number {
     this.data.playerMaxHealth = value;
     this.notify();
+
+    return value;
   }
 
-  public setPlayerXp(value: number) {
+  public setPlayerXp(value: number): number {
     this.data.playerXp = value;
     this.notify();
+
+    return value;
   }
 
-  public setPlayerMaxXp(value: number) {
+  public setPlayerMaxXp(value: number): number {
     this.data.playerMaxXp = value;
     this.notify();
+
+    return value;
   }
 
-  public setPlayerUpgradePoints(value: number) {
+  public setPlayerUpgradePoints(value: number): number {
     this.data.playerUpgradePoints = value;
     this.notify();
+
+    return value;
   }
 
-  public setPlayerKills(value: number) {
+  public setPlayerKills(value: number): number {
     this.data.playerKills = value;
     this.notify();
+
+    return value;
   }
 
-  public setPlayerEquippedHatId(value: number) {
+  public setPlayerEquippedHatId(value: number): number {
     this.data.playerEquippedHatId = value;
     this.setLocalStorage("cowpokePlayerEquippedHatId", value);
     this.notify();
+
+    return value;
   }
 
-  public setPlayerEquippedGunId(value: number) {
+  public setPlayerEquippedGunId(value: number): number {
     this.data.playerEquippedGunId = value;
     this.setLocalStorage("cowpokePlayerEquippedGunId", value);
     this.notify();
+
+    return value;
   }
 
-  public setPlayerOwnedHatIds(value: number[]) {
+  public setPlayerOwnedHatIds(value: number[]): number[] {
     this.data.playerOwnedHatIds = value;
     this.setLocalStorage("cowpokePlayerOwnedHatIds", value);
     this.notify();
+
+    return value;
   }
 
-  public setPlayerOwnedGunIds(value: number[]) {
+  public setPlayerOwnedGunIds(value: number[]): number[] {
     this.data.playerOwnedGunIds = value;
     this.setLocalStorage("cowpokePlayerOwnedGunIds", value);
     this.notify();
+
+    return value;
   }
 
-  public setPermaDamageLevel(value: number) {
+  public setPermaDamageLevel(value: number): number {
     this.data.permaDamageLevel = value;
     this.setLocalStorage("cowpokePlayerPermaDamageLevel", value);
     this.notify();
+
+    return value;
   }
 
-  public setPermaHealthLevel(value: number) {
+  public setPermaHealthLevel(value: number): number {
     this.data.permaHealthLevel = value;
     this.setLocalStorage("cowpokePlayerPermaHealthLevel", value);
     this.notify();
+
+    return value;
   }
 
-  public setPermaCombatLevel(value: number) {
+  public setPermaCombatLevel(value: number): number {
     this.data.permaCombatLevel = value;
     this.setLocalStorage("cowpokePlayerPermaCombatLevel", value);
     this.notify();
+
+    return value;
   }
 
-  public setPermaElementLevel(value: number) {
+  public setPermaElementLevel(value: number): number {
     this.data.permaElementLevel = value;
     this.setLocalStorage("cowpokePlayerPermaElementLevel", value);
     this.notify();
+
+    return value;
   }
 
   // Enemy methods
-  public setEnemyName(value: string) {
+  public setEnemyName(value: string): string {
     this.data.enemyName = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyLevel(value: number) {
+  public setEnemyLevel(value: number): number {
     this.data.enemyLevel = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyHealth(value: number) {
+  public setEnemyHealth(value: number): number {
     this.data.enemyHealth = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyMaxHealth(value: number) {
+  public setEnemyMaxHealth(value: number): number {
     this.data.enemyMaxHealth = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyXp(value: number) {
+  public setEnemyXp(value: number): number {
     this.data.enemyXp = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyMaxXp(value: number) {
+  public setEnemyMaxXp(value: number): number {
     this.data.enemyMaxXp = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyUpgradePoints(value: number) {
+  public setEnemyUpgradePoints(value: number): number {
     this.data.enemyUpgradePoints = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyKills(value: number) {
+  public setEnemyKills(value: number): number {
     this.data.enemyKills = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyEquippedHatId(value: number) {
+  public setEnemyEquippedHatId(value: number): number {
     // Not saved to localStorage as enemies don't have persistent data
     this.data.enemyEquippedHatId = value;
     this.notify();
+
+    return value;
   }
 
-  public setEnemyEquippedGunId(value: number) {
+  public setEnemyEquippedGunId(value: number): number {
     // Not saved to localStorage as enemies don't have persistent data
     this.data.enemyEquippedGunId = value;
     this.notify();
+
+    return value;
   }
 
   // Game mode methods
-  public setAutoMode(value: boolean) {
+  public setAutoMode(value: boolean): boolean {
     this.data.autoMode = value;
     this.setLocalStorage("cowpokeAutoMode", value);
     this.notify();
+
+    return value;
   }
 
-  public setAutoRestart(value: boolean) {
+  public setAutoRestart(value: boolean): boolean {
     this.data.autoRestart = value;
     this.setLocalStorage("cowpokeAutoRestart", value);
     this.notify();
+
+    return value;
   }
 
-  public setFastMode(value: boolean) {
+  public setFastMode(value: boolean): boolean {
     this.data.fastMode = value;
     this.setLocalStorage("cowpokeFastMode", value);
     this.notify();
+
+    return value;
   }
 
-  public setFavoredElement(value: null | "rock" | "paper" | "scissors") {
+  public setFavoredElement(
+    value: null | "rock" | "paper" | "scissors"
+  ): null | "rock" | "paper" | "scissors" {
     this.data.favoredElement = value;
     this.notify();
+
+    return value;
   }
 
-  public setFavoredCombat(value: null | "attack" | "defend" | "counter") {
+  public setFavoredCombat(
+    value: null | "attack" | "defend" | "counter"
+  ): null | "attack" | "defend" | "counter" {
     this.data.favoredCombat = value;
     this.notify();
+
+    return value;
   }
 
   // Stats methods
-  public setLifetimeKills(value: number) {
+  public setLifetimeKills(value: number): number {
     this.data.lifetimeKills = value;
     this.setLocalStorage("cowpokeLifetimeKills", value);
     this.notify();
+
+    return value;
   }
 
-  public setLifetimeFurthestLevelInPlaythrough(value: number) {
+  public setLifetimeFurthestLevelInPlaythrough(value: number): number {
     this.data.lifetimeFurthestLevelInPlaythrough = value;
     this.setLocalStorage("cowpokeLifetimeFurthestLevelInPlaythrough", value);
     this.notify();
+
+    return value;
   }
 
-  public setLifetimeMostKillsInPlaythrough(value: number) {
+  public setLifetimeMostKillsInPlaythrough(value: number): number {
     this.data.lifetimeMostKillsInPlaythrough = value;
     this.setLocalStorage("cowpokeLifetimeMostKillsInPlaythrough", value);
     this.notify();
+
+    return value;
   }
 
   // Settings seen methods
-  public setSettingsSeenHatIds(value: number[]) {
+  public setSettingsSeenHatIds(value: number[]): number[] {
     this.data.settingsSeenHatIds = value;
     this.setLocalStorage("cowpokeSettingsSeenHatIds", value);
     this.notify();
+
+    return value;
   }
 
-  public setSettingsSeenGunIds(value: number[]) {
+  public setSettingsSeenGunIds(value: number[]): number[] {
     this.data.settingsSeenGunIds = value;
     this.setLocalStorage("cowpokeSettingsSeenGunIds", value);
     this.notify();
+
+    return value;
   }
 
   public resetData() {

--- a/src/games/cowpoke/scenes/main-game-scene.ts
+++ b/src/games/cowpoke/scenes/main-game-scene.ts
@@ -203,9 +203,7 @@ export class MainGameScene extends Generic2DGameScene {
     this.favoredCombat = gameData.favoredCombat;
 
     // Update fast mode + durations
-    this.fastMode = gameData.fastMode;
-
-    if (this.fastMode) {
+    if (gameData.fastMode) {
       this.combatDuration = COMBAT_DURATION_FAST_MODE;
       this.updateFavoredInterval = UPDATE_FAVORED_INTERVAL_FAST_MODE;
       this.movingDuration = MOVING_DURATION_FAST_MODE;
@@ -253,15 +251,18 @@ export class MainGameScene extends Generic2DGameScene {
     const gameData = gameDataStore.getSnapshot();
 
     if (this.player) {
+      // eslint-disable-next-line no-restricted-syntax
       gameDataStore.setLifetimeKills(
         gameData.lifetimeKills + this.player.kills
       );
 
       if (this.player.level > gameData.lifetimeFurthestLevelInPlaythrough) {
+        // eslint-disable-next-line no-restricted-syntax
         gameDataStore.setLifetimeFurthestLevelInPlaythrough(this.player.level);
       }
 
       if (this.player.kills > gameData.lifetimeMostKillsInPlaythrough) {
+        // eslint-disable-next-line no-restricted-syntax
         gameDataStore.setLifetimeMostKillsInPlaythrough(this.player.kills);
       }
     }
@@ -439,7 +440,7 @@ export class MainGameScene extends Generic2DGameScene {
             nextElement = "rock"; // fallback if null or undefined
             break;
         }
-        gameDataStore.setFavoredElement(nextElement);
+        this.favoredElement = gameDataStore.setFavoredElement(nextElement);
 
         // Cycle through combat: attack -> defend -> counter -> attack
         let nextCombat: "attack" | "defend" | "counter";
@@ -457,7 +458,7 @@ export class MainGameScene extends Generic2DGameScene {
             nextCombat = "attack"; // fallback if null or undefined
             break;
         }
-        gameDataStore.setFavoredCombat(nextCombat);
+        this.favoredCombat = gameDataStore.setFavoredCombat(nextCombat);
 
         this.lastUpdateFavoredTime = time;
       }

--- a/src/games/flip-tile/game-data-store.ts
+++ b/src/games/flip-tile/game-data-store.ts
@@ -25,14 +25,18 @@ class GameDataStore extends SyncedStore<GameData> {
     return { ...this.data };
   }
 
-  public setScore(value: number) {
+  public setScore(value: number): number {
     this.data.score = value;
     this.notify();
+
+    return value;
   }
 
-  public setSolutionRevealed(value: boolean) {
+  public setSolutionRevealed(value: boolean): boolean {
     this.data.solutionRevealed = value;
     this.notify();
+
+    return value;
   }
 
   public resetData() {

--- a/src/games/flip-tile/scenes/main-game-scene.ts
+++ b/src/games/flip-tile/scenes/main-game-scene.ts
@@ -143,7 +143,7 @@ export class MainGameScene extends Generic2DGameScene {
   resetRevealSolutionToggle() {
     // If the solution is revealed, we need to reset it to false
     if (this.solutionRevealed) {
-      gameDataStore.setSolutionRevealed(false);
+      this.solutionRevealed = gameDataStore.setSolutionRevealed(false);
     }
   }
 
@@ -250,7 +250,7 @@ export class MainGameScene extends Generic2DGameScene {
         }
 
         // Update the game data store with the new score
-        gameDataStore.setScore(desiredScore);
+        this.score = gameDataStore.setScore(desiredScore);
         document.dispatchEvent(new CustomEvent("scoreChange"));
       }
 
@@ -265,7 +265,7 @@ export class MainGameScene extends Generic2DGameScene {
   handleToggleSolution = (event: Event) => {
     const customEvent = event as CustomEvent<{ state: string }>;
     if (customEvent.detail.state === "on") {
-      gameDataStore.setSolutionRevealed(true);
+      this.solutionRevealed = gameDataStore.setSolutionRevealed(true);
       this.revealedAtLeastOnceThisLevel = true;
 
       // Show the solution for all tiles
@@ -279,7 +279,7 @@ export class MainGameScene extends Generic2DGameScene {
         }
       }
     } else {
-      gameDataStore.setSolutionRevealed(false);
+      this.solutionRevealed = gameDataStore.setSolutionRevealed(false);
 
       // Hide the solution for all tiles
       for (let row = 0; row < tiles.length; row++) {

--- a/src/games/game-of-life/components/UiOverlay.tsx
+++ b/src/games/game-of-life/components/UiOverlay.tsx
@@ -29,7 +29,13 @@ const UiOverlay: React.FC = () => {
   } = UseGameData();
 
   const handleToggleAutoMode = () => {
-    setAutoPlayMode(!autoPlayMode);
+    const desiredAutoPlayMode = !autoPlayMode;
+    setAutoPlayMode(desiredAutoPlayMode);
+
+    // If the game is paused, unpause it if autoplay is turned on (false -> true)
+    if (paused && desiredAutoPlayMode) {
+      handleTogglePause();
+    }
   };
 
   const handleTogglePause = () => {
@@ -45,7 +51,13 @@ const UiOverlay: React.FC = () => {
   };
 
   const handleToggleDisco = () => {
-    setDiscoMode(!discoMode);
+    const desiredDiscoMode = !discoMode;
+    setDiscoMode(desiredDiscoMode);
+
+    // If the game is paused, unpause it if disco mode is turned on (false -> true)
+    if (paused && desiredDiscoMode) {
+      handleTogglePause();
+    }
   };
 
   useEffect(() => {

--- a/src/games/game-of-life/game-data-store.ts
+++ b/src/games/game-of-life/game-data-store.ts
@@ -31,29 +31,39 @@ class GameDataStore extends SyncedStore<GameData> {
     return { ...this.data };
   }
 
-  public setPopulation(value: number) {
+  public setPopulation(value: number): number {
     this.data.population = value;
     this.notify();
+
+    return value;
   }
 
-  public setGeneration(value: number) {
+  public setGeneration(value: number): number {
     this.data.generation = value;
     this.notify();
+
+    return value;
   }
 
-  public setPaused(value: boolean) {
+  public setPaused(value: boolean): boolean {
     this.data.paused = value;
     this.notify();
+
+    return value;
   }
 
-  public setAutoPlayMode(value: boolean) {
+  public setAutoPlayMode(value: boolean): boolean {
     this.data.autoPlayMode = value;
     this.notify();
+
+    return value;
   }
 
-  public setDiscoMode(value: boolean) {
+  public setDiscoMode(value: boolean): boolean {
     this.data.discoMode = value;
     this.notify();
+
+    return value;
   }
 
   public resetData() {

--- a/src/games/game-of-life/scenes/main-game-scene.ts
+++ b/src/games/game-of-life/scenes/main-game-scene.ts
@@ -164,23 +164,11 @@ export class MainGameScene extends Generic2DGameScene {
   };
 
   setGameDataFromStore(gameData: GameData) {
-    const incomingAutoPlayMode = this.autoPlayMode;
-    const incomingDiscoMode = this.discoMode;
-
     this.population = gameData.population;
     this.generation = gameData.generation;
     this.paused = gameData.paused;
     this.autoPlayMode = gameData.autoPlayMode;
     this.discoMode = gameData.discoMode;
-
-    // If the game is paused, unpause it if autoplay is turned on (false -> true)
-    if (this.paused && !incomingAutoPlayMode && this.autoPlayMode) {
-      gameDataStore.setPaused(false);
-    }
-    // If the game is paused, unpause it if disco mode is turned on (false -> true)
-    if (this.paused && !incomingDiscoMode && this.discoMode) {
-      gameDataStore.setPaused(false);
-    }
   }
 
   update(time: number, delta: number) {
@@ -292,7 +280,7 @@ export class MainGameScene extends Generic2DGameScene {
       newGenerationVal = 0;
     }
 
-    gameDataStore.setGeneration(newGenerationVal);
+    this.generation = gameDataStore.setGeneration(newGenerationVal);
   }
 
   updatePopulation(newPopulationVal: number) {
@@ -305,11 +293,11 @@ export class MainGameScene extends Generic2DGameScene {
     // ONLY IF NOT IN AUTOPLAY MODE!
     if (newPopulationVal == 0 && !this.autoPlayMode) {
       if (!this.paused) {
-        gameDataStore.setPaused(true);
+        this.paused = gameDataStore.setPaused(true);
       }
     }
 
-    gameDataStore.setPopulation(newPopulationVal);
+    this.population = gameDataStore.setPopulation(newPopulationVal);
   }
 
   checkForNeighborTiles(
@@ -394,7 +382,7 @@ export class MainGameScene extends Generic2DGameScene {
     this.resetTiles();
 
     if (!this.paused) {
-      gameDataStore.setPaused(true);
+      this.paused = gameDataStore.setPaused(true);
     }
   };
 
@@ -491,7 +479,7 @@ export class MainGameScene extends Generic2DGameScene {
       this.runGameOfLifeIteration();
     } else {
       // Manually pause on advance if playing already
-      gameDataStore.setPaused(true);
+      this.paused = gameDataStore.setPaused(true);
     }
   }
 
@@ -584,7 +572,7 @@ export class MainGameScene extends Generic2DGameScene {
       desiredColorTheme = 0;
     }
 
-    settingsStore.setColorTheme(desiredColorTheme);
+    this.colorTheme = settingsStore.setColorTheme(desiredColorTheme);
   }
 
   decreaseToPreviousColorTheme() {
@@ -593,7 +581,7 @@ export class MainGameScene extends Generic2DGameScene {
       desiredColorTheme = tileAndBackgroundColors.length - 1;
     }
 
-    settingsStore.setColorTheme(desiredColorTheme);
+    this.colorTheme = settingsStore.setColorTheme(desiredColorTheme);
   }
 
   destroyTiles() {

--- a/src/games/game-of-life/settings-store.ts
+++ b/src/games/game-of-life/settings-store.ts
@@ -44,45 +44,61 @@ class SettingsStore extends SyncedStore<Settings> {
     return { ...this.data };
   }
 
-  public setUpdateInterval(value: number) {
+  public setUpdateInterval(value: number): number {
     this.data.updateInterval = value;
     this.notify();
+
+    return value;
   }
 
-  public setUnderpopulation(value: number) {
+  public setUnderpopulation(value: number): number {
     this.data.underpopulation = value;
     this.notify();
+
+    return value;
   }
 
-  public setOverpopulation(value: number) {
+  public setOverpopulation(value: number): number {
     this.data.overpopulation = value;
     this.notify();
+
+    return value;
   }
 
-  public setReproduction(value: number) {
+  public setReproduction(value: number): number {
     this.data.reproduction = value;
     this.notify();
+
+    return value;
   }
 
-  public setColorTheme(value: number) {
+  public setColorTheme(value: number): number {
     this.data.colorTheme = value;
     this.setLocalStorage("gameOfLifeColorTheme", value);
     this.notify();
+
+    return value;
   }
 
-  public setAutoPause(value: boolean) {
+  public setAutoPause(value: boolean): boolean {
     this.data.autoPause = value;
     this.notify();
+
+    return value;
   }
 
-  public setInfiniteEdges(value: boolean) {
+  public setInfiniteEdges(value: boolean): boolean {
     this.data.infiniteEdges = value;
     this.notify();
+
+    return value;
   }
 
-  public setDiagonalNeighbors(value: boolean) {
+  public setDiagonalNeighbors(value: boolean): boolean {
     this.data.diagonalNeighbors = value;
     this.notify();
+
+    return value;
   }
 
   public resetData() {

--- a/src/games/game-of-life/tile.ts
+++ b/src/games/game-of-life/tile.ts
@@ -54,7 +54,7 @@ export class Tile extends GameObject {
 
       // Autopause the game if specified to do such
       if (!this.scene!.paused && this.scene!.autoPause) {
-        gameDataStore.setPaused(true);
+        this.scene!.paused = gameDataStore.setPaused(true);
       }
     }
 

--- a/src/games/game-template/game-data-store.ts
+++ b/src/games/game-template/game-data-store.ts
@@ -23,9 +23,11 @@ class GameDataStore extends SyncedStore<GameData> {
     return { ...this.data };
   }
 
-  public setScore(value: number) {
+  public setScore(value: number): number {
     this.data.score = value;
     this.notify();
+
+    return value;
   }
 
   public resetData() {

--- a/src/games/game-template/scenes/main-game-scene.ts
+++ b/src/games/game-template/scenes/main-game-scene.ts
@@ -181,7 +181,7 @@ export class MainGameScene extends Generic2DGameScene {
     this.balls.push(ball);
 
     // Update the game data store with the new "score", which is the number of balls
-    gameDataStore.setScore(this.balls.length);
+    this.score = gameDataStore.setScore(this.balls.length);
     document.dispatchEvent(new CustomEvent("scoreChange"));
   }
 


### PR DESCRIPTION
Data Store cleanup:
- Value is not instantly updated when set in store. This can cause subtle bugs where user expects this.someValue to be updated immediately after setting it in the code
- Added eslint rule and made it to where users are expected to return values. That way they can design around the issue and locally update vars by default

Cowpoek fine tuning:
- Made the game harder at first